### PR TITLE
Fix version to 15.8, so .NET Core SDK targets won't compain about MSBuild version <15.3.0

### DIFF
--- a/debian/patches/fixed-build-version.diff
+++ b/debian/patches/fixed-build-version.diff
@@ -30,7 +30,7 @@ index 9e925132..606972ec 100644
 +          Condition="'$(DisableNerdbankVersioning)' == 'true'">
 +    <PropertyGroup>
 +      <AssemblyVersion>15.1.0.0</AssemblyVersion>
-+      <FileVersion>15.1.8.0</FileVersion>
++      <FileVersion>15.8.0.0</FileVersion>
 +      <InformationalVersion>$(FileVersion)-mono</InformationalVersion>
 +    </PropertyGroup>
 +  </Target>


### PR DESCRIPTION
https://github.com/mono/linux-packaging-msbuild/issues/5