### PR TITLE
Actually install NuGet SDK resolver

### DIFF
--- a/debian/msbuild.install
+++ b/debian/msbuild.install
@@ -1,6 +1,7 @@
 /usr/bin/
 /usr/lib/mono/xbuild/
 /usr/lib/mono/msbuild/15.0/bin/Sdks/
+/usr/lib/mono/msbuild/15.0/bin/SdkResolvers/NuGet.MSBuildSdkResolver
 /usr/lib/mono/msbuild/15.0/bin/*.config
 /usr/lib/mono/msbuild/15.0/bin/*.dll
 /usr/lib/mono/msbuild/15.0/bin/*.overridetasks


### PR DESCRIPTION
Currently custom SDKs from NuGet packages don't work because of missing NuGet.MSBuildSdkResolver.dll